### PR TITLE
[ios only] add features: method readFileContent; option "update" in method copyToCloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,3 +99,24 @@ RNCloudFs.listFiles({targetPath: path, scope: scope})
 _targetPath_: a path representing a folder to list files from
 
 _scope_: a string to specify if the files are the user-visible documents (`visible`) or the app-visible documents (`hidden`)
+
+### readFileContent (options)
+Reads a file content. The scope determines if the file listing takes place in the app folder or the public user documents folder.
+
+```javascript
+const path = "dirA/dirB";
+const scope = 'hidden';
+
+RNCloudFs.readFileContent({targetPath: path, scope: scope})
+  .then((res) => {
+    console.log("it worked", res);
+  })
+  .catch((err) => {
+    console.warn("it failed", err);
+  })
+```
+
+_targetPath_: a path representing a file which content you want to read
+
+_scope_: a string to specify if the files are the user-visible documents (`visible`) or the app-visible documents (`hidden`)
+

--- a/README.md
+++ b/README.md
@@ -43,12 +43,14 @@ const sourceUri = {uri: 'https://foo.com/bar.pdf'};
 const destinationPath = "foo-bar/docs/info.pdf";
 const mimeType = null;
 const scope = 'visible';
+const update = false;
 
 RNCloudFs.copyToCloud({
   sourcePath: sourceUri, 
   targetPath: destinationPath, 
-  mimeType: mimeType, 
-  scope: scope
+  mimeType, 
+  scope,
+  update
 })
   .then((path) => {
     console.log("it worked", path);
@@ -75,6 +77,8 @@ _mimeType_:  a mime type to store the file with **or null** (android only) , e.g
  * `image/jpeg`
 
 _scope_: a string to specify if the user can access the document (`visible`) or not (`hidden`)
+
+_update_: a boolean to specify if we want to update an existing item instead of creating a new one
 
 ### listFiles (options)
 Lists files in a directory along with some file metadata.  The scope determines if the file listing takes place in the app folder or the public user documents folder.

--- a/ios/RNCloudFs.m
+++ b/ios/RNCloudFs.m
@@ -244,6 +244,33 @@ RCT_EXPORT_METHOD(copyToCloud:(NSDictionary *)options
     }
 }
 
+RCT_EXPORT_METHOD(readFileContent:(NSDictionary *)options
+                   resolver:(RCTPromiseResolveBlock)resolve
+                   rejecter:(RCTPromiseRejectBlock)reject) {
+    
+    NSString *destinationPath = [options objectForKey:@"targetPath"];
+    NSString *scope = [options objectForKey:@"scope"];
+    bool documentsFolder = !scope || [scope caseInsensitiveCompare:@"visible"] == NSOrderedSame;
+
+    NSFileManager* fileManager = [NSFileManager defaultManager];
+    
+    NSURL *ubiquityURL = documentsFolder ? [self icloudDocumentsDirectory] : [self icloudDirectory];
+    
+    if (ubiquityURL) {
+        NSURL* dir = [ubiquityURL URLByAppendingPathComponent:destinationPath];
+        NSString* dirPath = [dir.path stringByStandardizingPath];
+
+        NSString *content = [NSString stringWithContentsOfFile:dirPath encoding:NSUTF8StringEncoding error:nil];
+        
+        RCTLogTrace(@"Has read file content from %@", dir);
+
+        return resolve(content);
+    } else {
+        NSLog(@"Could not retrieve a ubiquityURL");
+        return reject(@"error", [NSString stringWithFormat:@"could not get from iCloud drive '%@'", destinationPath], nil);
+    }
+}
+
 - (void) moveToICloudDirectory:(bool) documentsFolder :(NSString *)tempFile :(NSString *)destinationPath                                 :(bool) update
                               :(RCTPromiseResolveBlock)resolver
                               :(RCTPromiseRejectBlock)rejecter {

--- a/ios/RNCloudFs.m
+++ b/ios/RNCloudFs.m
@@ -39,7 +39,7 @@ RCT_EXPORT_METHOD(createFile:(NSDictionary *) options
         return reject(@"error", error.description, nil);
     }
 
-    [self moveToICloudDirectory:documentsFolder :tempFile :destinationPath :resolve :reject];
+    [self moveToICloudDirectory:documentsFolder :tempFile :destinationPath :false :resolve :reject];
 }
 
 RCT_EXPORT_METHOD(fileExists:(NSDictionary *)options
@@ -165,6 +165,7 @@ RCT_EXPORT_METHOD(copyToCloud:(NSDictionary *)options
     NSDictionary *source = [options objectForKey:@"sourcePath"];
     NSString *destinationPath = [options objectForKey:@"targetPath"];
     NSString *scope = [options objectForKey:@"scope"];
+    BOOL update = [[options objectForKey:@"update"] boolValue];
     bool documentsFolder = !scope || [scope caseInsensitiveCompare:@"visible"] == NSOrderedSame;
 
     NSFileManager* fileManager = [NSFileManager defaultManager];
@@ -189,7 +190,7 @@ RCT_EXPORT_METHOD(copyToCloud:(NSDictionary *)options
                 NSString *filename = [sourceUri lastPathComponent];
                 NSString *tempFile = [NSTemporaryDirectory() stringByAppendingPathComponent:filename];
                 [data writeToFile:tempFile atomically:YES];
-                [self moveToICloudDirectory:documentsFolder :tempFile :destinationPath :resolve :reject];
+                [self moveToICloudDirectory:documentsFolder :tempFile :destinationPath :update :resolve :reject];
             } else {
                 RCTLogTrace(@"source file does not exist %@", sourceUri);
                 return reject(@"error", [NSString stringWithFormat:@"failed to copy asset '%@'", sourceUri], nil);
@@ -211,12 +212,18 @@ RCT_EXPORT_METHOD(copyToCloud:(NSDictionary *)options
             NSString *tempFile = [NSTemporaryDirectory() stringByAppendingPathComponent:filename];
 
             NSError *error;
+            
+            if(update && [fileManager fileExistsAtPath:tempFile isDirectory:nil]) {
+                // in update mode, if a temp file already exists at destination path, we need to delete it to avoid errors
+                [fileManager removeItemAtPath:tempFile error:&error];
+            }
+            
             [fileManager copyItemAtPath:[sourceURL path] toPath:tempFile error:&error];
             if(error) {
                 return reject(@"error", error.description, nil);
             }
 
-            [self moveToICloudDirectory:documentsFolder :tempFile :destinationPath :resolve :reject];
+            [self moveToICloudDirectory:documentsFolder :tempFile :destinationPath :update :resolve :reject];
         } else {
             NSLog(@"source file does not exist %@", sourceUri);
             return reject(@"error", [NSString stringWithFormat:@"no such file or directory, open '%@'", sourceUri], nil);
@@ -229,7 +236,7 @@ RCT_EXPORT_METHOD(copyToCloud:(NSDictionary *)options
             NSString *filename = [sourceUri lastPathComponent];
             NSString *tempFile = [NSTemporaryDirectory() stringByAppendingPathComponent:filename];
             [urlData writeToFile:tempFile atomically:YES];
-            [self moveToICloudDirectory:documentsFolder :tempFile :destinationPath :resolve :reject];
+            [self moveToICloudDirectory:documentsFolder :tempFile :destinationPath :update :resolve :reject];
         } else {
             RCTLogTrace(@"source file does not exist %@", sourceUri);
             return reject(@"error", [NSString stringWithFormat:@"cannot download '%@'", sourceUri], nil);
@@ -237,20 +244,20 @@ RCT_EXPORT_METHOD(copyToCloud:(NSDictionary *)options
     }
 }
 
-- (void) moveToICloudDirectory:(bool) documentsFolder :(NSString *)tempFile :(NSString *)destinationPath
+- (void) moveToICloudDirectory:(bool) documentsFolder :(NSString *)tempFile :(NSString *)destinationPath                                 :(bool) update
                               :(RCTPromiseResolveBlock)resolver
                               :(RCTPromiseRejectBlock)rejecter {
 
     if(documentsFolder) {
         NSURL *ubiquityURL = [self icloudDocumentsDirectory];
-        [self moveToICloud:ubiquityURL :tempFile :destinationPath :resolver :rejecter];
+        [self moveToICloud:ubiquityURL :tempFile :destinationPath :update :resolver :rejecter];
     } else {
         NSURL *ubiquityURL = [self icloudDirectory];
-        [self moveToICloud:ubiquityURL :tempFile :destinationPath :resolver :rejecter];
+        [self moveToICloud:ubiquityURL :tempFile :destinationPath :update :resolver :rejecter];
     }
 }
 
-- (void) moveToICloud:(NSURL *)ubiquityURL :(NSString *)tempFile :(NSString *)destinationPath
+- (void) moveToICloud:(NSURL *)ubiquityURL :(NSString *)tempFile :(NSString *)destinationPath :(bool) update
                      :(RCTPromiseResolveBlock)resolver
                      :(RCTPromiseRejectBlock)rejecter {
 
@@ -272,11 +279,13 @@ RCT_EXPORT_METHOD(copyToCloud:(NSDictionary *)options
 
         NSURL* uniqueFile = targetFile;
 
-        int count = 1;
-        while([fileManager fileExistsAtPath:uniqueFile.path]) {
-            NSString *uniqueName = [NSString stringWithFormat:@"%i.%@", count, name];
-            uniqueFile = [dir URLByAppendingPathComponent:uniqueName];
-            count++;
+        if(!update) {
+            int count = 1;
+            while([fileManager fileExistsAtPath:uniqueFile.path]) {
+                NSString *uniqueName = [NSString stringWithFormat:@"%i.%@", count, name];
+                uniqueFile = [dir URLByAppendingPathComponent:uniqueName];
+                count++;
+            }
         }
 
         RCTLogTrace(@"Target file: %@", uniqueFile.path);
@@ -286,6 +295,12 @@ RCT_EXPORT_METHOD(copyToCloud:(NSDictionary *)options
         }
 
         NSError *error;
+        
+        if(update && [fileManager fileExistsAtPath:uniqueFile.path isDirectory:nil]) {
+            // in update mode, if a icloud file already exists at destination path, we need to delete it to avoid errors
+            [fileManager removeItemAtPath:uniqueFile.path error:&error];
+        }
+        
         [fileManager setUbiquitous:YES itemAtURL:[NSURL fileURLWithPath:tempFile] destinationURL:uniqueFile error:&error];
         if(error) {
             return rejecter(@"error", error.description, nil);


### PR DESCRIPTION
Hi, I made these couple changes for my use case and thought it could be useful for others too. 

1) add method readFileContent, which returns a string with the content of the file at the specified path 

2) add the option 'update' (boolean) to the metod copyToCloud. You can set this option to true in case you want to update an already existing file at the specified path. Without this option, the method would just create a new file with a new name every time (this is still the behavior if update option is false or null) 